### PR TITLE
(fix): api-error in node_env

### DIFF
--- a/Utility/ApiError.js
+++ b/Utility/ApiError.js
@@ -1,3 +1,5 @@
+import { config } from "../config";
+
 class ApiError extends Error {
     /**
      * Custom API Error Handler
@@ -12,7 +14,7 @@ class ApiError extends Error {
         this.errors = Array.isArray(errors) ? errors : [errors]; // Ensure it's always an array
 
         // Capture stack trace for better debugging (excluding constructor call)
-        if (process.env.NODE_ENV !== 'production') {
+        if (config.NODE_ENV !== 'production') {
             Error.captureStackTrace(this, this.constructor);
         }
 

--- a/Utility/ApiError.js
+++ b/Utility/ApiError.js
@@ -12,7 +12,10 @@ class ApiError extends Error {
         this.errors = Array.isArray(errors) ? errors : [errors]; // Ensure it's always an array
 
         // Capture stack trace for better debugging (excluding constructor call)
-        Error.captureStackTrace(this, this.constructor);
+        if (process.env.NODE_ENV !== 'production') {
+            Error.captureStackTrace(this, this.constructor);
+        }
+
     }
 }
 

--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,8 @@
+// download the dotenv from npm
+
+// import dotenv from "dotenv";
+// dotenv.config();
+
+export const config = {
+  NODE_ENV : process.env.NODE_ENV || 'development',
+}


### PR DESCRIPTION
Capture the error only when node_env is `development`.
